### PR TITLE
fixed versions mismatch

### DIFF
--- a/python/generate_protobuf.sh
+++ b/python/generate_protobuf.sh
@@ -1,11 +1,10 @@
 #! /usr/bin/env bash
 
-python3 -m pip install -U grpcio_tools
+python3 -m pip install -r requirements/dev.txt
 
 python3 -m grpc_tools.protoc \
     -I../apis/ -I../third_party/googleapis \
     --python_out=. --grpc_python_out=. \
     ../apis/tinkoff/cloud/stt/v1/stt.proto ../apis/tinkoff/cloud/tts/v1/tts.proto ../apis/tinkoff/cloud/longrunning/v1/longrunning.proto
-
 
 find tinkoff -type d -exec touch {}/__init__.py \;

--- a/python/requirements/base.txt
+++ b/python/requirements/base.txt
@@ -1,4 +1,4 @@
-grpcio==1.33.2
-protobuf==3.12.4
+grpcio==1.45.0
+protobuf==3.19.4
 googleapis-common-protos==1.6.0
 requests==2.22.0

--- a/python/requirements/dev.txt
+++ b/python/requirements/dev.txt
@@ -1,2 +1,2 @@
 -r all.txt
-grpcio-tools==1.24.3
+grpcio-tools==1.45.0


### PR DESCRIPTION
In the previous pull request, Protobuf files were generated using GRPC tools version 1.45, but in the installation step recommended version of GRPC based on the requirements is grpcio==1.33.2, so the examples in the README file stopped working